### PR TITLE
#3: add a script to create users and run it automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,28 +53,30 @@ Usage
   This will launch the container in interactive mode, and mount the dir
   with the clones to the container's `/opt/tracker`.
 
-6. Create a new empty instance of `python-dev` using:
-
-  ```
-  rd-admin init
-  ```
-
-7. Run it using:
+6. Every time the container is run, the tracker is initialized and 3
+  users are created.  You can then run the tracker with:
 
   ```
   rd-start
   ```
 
-8. Your local instance of bugs.python.org should be available under
+7. Your local instance of bugs.python.org should be available at
   http://localhost:9999
+  On top of the two default users (`admin` and `anonymous`),
+  3 additional users are also available:
+  * `user`: a regular user
+  * `developer`: a developer (triager) that signed the cla
+  * `coordinator`: a coordinator and committer that signed the cla
+
+  You can login as any of these 3 users using `pass` as password.
 
 
 Notes
 -----
 * Every time you stop the container, all the users and issues you
   created will be deleted.
-* Every time you start the container, you will need to run
-  `rd-admin init` again and reinitialize the tracker.
+* Every time you start the container, the tracker is initialized
+  and the 3 users are created.
 * Once the container is running, you can start and stop the tracker
   with `rd-start` and `ctrl+c`.
 * When you register a new user, look in `python-dev/debugmail.txt`:

--- a/image/bin/createusers.py
+++ b/image/bin/createusers.py
@@ -1,0 +1,30 @@
+"""
+Create 3 users in the db:
+* user: a regular user
+* developer: a developer (triager) that signed the cla
+* coordinator: a coordinator and committer that signed the cla
+
+Most of the fields are the same as the username.
+The password for all the users is 'pass'.
+"""
+
+import subprocess
+
+rdadmin = ['/home/tracker/bin/roundup-admin', '-i', '/opt/tracker/python-dev']
+
+users = ['user', 'developer', 'coordinator']
+roles = []
+
+for user in users:
+    roles.append(user.capitalize())
+    r = ','.join(roles)
+    ic = 1 if user == 'coordinator' else 0  # only coord is committer
+    args = ('create user username={u} address={u}@bugs.python.org '
+            'password=pass realname={u} github={u} roles={r} '
+            'iscommitter={ic}'.format(u=user, r=r, ic=ic))
+    if user in {'developer', 'coordinator'}:
+        args += ' contrib_form=1 contrib_form_date=2017-03-22.00:00:00'
+
+    print('Creating user:', user)
+    print('    - user id:', end=' ', flush=True)
+    subprocess.run(rdadmin + args.split())

--- a/image/bin/createusers.py
+++ b/image/bin/createusers.py
@@ -16,12 +16,15 @@ users = ['user', 'developer', 'coordinator']
 roles = []
 
 for user in users:
+    # listing the role is not enough -- all lower-level roles
+    # must be added too (e.g. Coordinator,Developer,User)
     roles.append(user.capitalize())
     r = ','.join(roles)
     ic = 1 if user == 'coordinator' else 0  # only coord is committer
     args = ('create user username={u} address={u}@bugs.python.org '
             'password=pass realname={u} github={u} roles={r} '
             'iscommitter={ic}'.format(u=user, r=r, ic=ic))
+    # developer and coordinator signed the cla
     if user in {'developer', 'coordinator'}:
         args += ' contrib_form=1 contrib_form_date=2017-03-22.00:00:00'
 

--- a/image/init.sh
+++ b/image/init.sh
@@ -10,6 +10,13 @@ function stop_all() {
 
 trap stop_all HUP INT QUIT KILL TERM
 
+
+# initialize the db (pwd: admin) and create users
+sleep 5  # wait for PG to start...
+/home/tracker/bin/roundup-admin -i /opt/tracker/python-dev init admin
+python3 /home/tracker/bin/createusers.py
+
+
 if [ $# -eq 0 ]; then
     /bin/bash
 else


### PR DESCRIPTION
This PR includes 2 changesets:
1) add a new script that creates default users (see docstring for detauls);
2) this script, together with `rd-admin init` are added to `init.sh`

The final result is that now, when the container is started, it will have an initialized db with 3 default users.