### PR TITLE
Check for postgres startup in rd-admin instead of init.sh.

### DIFF
--- a/image/bin/roundup-admin
+++ b/image/bin/roundup-admin
@@ -8,4 +8,12 @@ import sys
 sys.path.append(roundup_path)
 
 from roundup.scripts.roundup_admin import run
-run()
+from roundup.hyperdb import DatabaseError
+
+while True:
+    try:
+        run()
+    except DatabaseError:
+        pass
+    else:
+        break

--- a/image/init.sh
+++ b/image/init.sh
@@ -1,26 +1,19 @@
 #!/bin/bash
 
-echo "===== Starting postgresql ====="
+echo "* Starting postgresql..."
 sudo /etc/init.d/postgresql restart >/dev/null
 
 function stop_all() {
-    echo "===== Stopping postgresql ====="
+    echo "* Stopping postgresql..."
     sudo /etc/init.d/postgresql stop
 }
 
 trap stop_all HUP INT QUIT KILL TERM
 
 
-# wait for postgresql to be available
-while true; do
-    curl --max-time 2 --fail --silent http://localhost:5432/
-    if [[ $? -eq 52 ]]; then
-        break
-    fi
-    sleep 1
-done
 
 # initialize the db (pwd: admin) and create users
+echo "* Initializing Roundup..."
 /home/tracker/bin/roundup-admin -i /opt/tracker/python-dev init admin
 python3 /home/tracker/bin/createusers.py
 


### PR DESCRIPTION
I tried a few solutions, but ISTM that as soon as `/etc/init.d/postgresql start` returns, both `curl` and `psql` can connect, but `rd-admin` still fails.
I ended up using a EAFP approach and check for db errors in rd-admin.
This seems to work fine for now, however I might have to update the PR if the try/except masks other DB failures.